### PR TITLE
Set "development" mode for webpack.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ var buildPath = path.join(__dirname, 'dist');
 module.exports = {
   context: srcPath,
   entry: path.join(srcPath, 'js', 'client.js'),
+  mode: "development",
   output: {
       path: buildPath,
       filename: "bundle.js"


### PR DESCRIPTION
Set "development" mode for webpack to avoid long production building.